### PR TITLE
Limit the number of attempts to query job status to 5 retries

### DIFF
--- a/main.py
+++ b/main.py
@@ -101,7 +101,8 @@ class ExternalQueryHandler:
 
         write_metric_calculations_to_file(self.metadata['data_filepath'], subset_metric_calculations)
         self.result = True
-      except (ValueError, telescope.external.QueryFailure) as caught_error:
+      except (ValueError, telescope.external.BigQueryJobFailure,
+              telescope.external.BigQueryCommunicationError) as caught_error:
         logger.error("Caught {caught_error} for ({site}, {client_provider}, {metric}).".format(
             caught_error = caught_error, site = self.metadata['site'],
             client_provider = self.metadata['client_provider'], metric = self.metadata['metric']))
@@ -430,7 +431,8 @@ def process_selector_queue(selector_queue, google_auth_config,
     try:
       bq_query_call = telescope.external.BigQueryCall(google_auth_config)
       bq_job_id = bq_query_call.run_asynchronous_query(bq_query_string, batch_mode = is_batched_query)
-    except (SSLError, telescope.external.QueryFailure) as caught_error:
+    except (SSLError, telescope.external.BigQueryJobFailure,
+            telescope.external.BigQueryCommunicationError) as caught_error:
       logger.warn(("Caught request error {caught_error} on query, cooling " +
                     "down for a minute.").format(caught_error = caught_error))
       selector_queue.put( (bq_query_string, bq_table_span, thread_metadata, True) )

--- a/telescope/external.py
+++ b/telescope/external.py
@@ -143,7 +143,7 @@ class BigQueryJobResultCollector(object):
     """Wait until a job is complete and gather all results.
 
     Args:
-      job_id: (int) Job ID for which to retrieve results.
+      job_id: (str) Job ID for which to retrieve results.
 
     Returns:
       (list) A list of result rows from the completed BigQuery job.
@@ -172,7 +172,7 @@ class BigQueryJobResultCollector(object):
     may be greater or less than the total number of rows available.
 
     Args:
-      job_id: (int) Job ID for which to retrieve results.
+      job_id: (str) Job ID for which to retrieve results.
       page_token: Token that indicates which page of results for which to
         retrieve results or None to retrieve the first page of results.
 
@@ -195,12 +195,11 @@ class BigQueryJobResultCollector(object):
         if retries_remaining > 0:
           sleep_seconds = 10
           logging.warning(('Failed to communicate with BigQuery to retrieve '
-                           'job %d. Retrying in %d seconds... (%d attempts '
+                           'job %s. Retrying in %d seconds... (%d attempts '
                            'remaining)'),
                           job_id, sleep_seconds, retries_remaining)
           time.sleep(sleep_seconds)
           retries_remaining -= 1
-          continue
         else:
           raise e
 

--- a/telescope/external_test.py
+++ b/telescope/external_test.py
@@ -73,11 +73,9 @@ class BigQueryJobResultCollectorTest(unittest.TestCase):
     self.addCleanup(sleep_patch.stop)
     sleep_patch.start()
 
-    self.dummy_job_id = 42
-    self.dummy_project_id = 57
     self.mock_jobs_service = mock.Mock()
     self.collector = external.BigQueryJobResultCollector(self.mock_jobs_service,
-                                                         self.dummy_project_id)
+                                                         'dummy_project_id')
 
   def test_single_page_multiple_rows(self):
     mock_result_rows = [
@@ -87,14 +85,14 @@ class BigQueryJobResultCollectorTest(unittest.TestCase):
     self.mock_jobs_service.getQueryResults().execute.return_value = (
         mock_response)
     rows_expected = mock_result_rows
-    rows_actual = self.collector.collect_results(self.dummy_job_id)
+    rows_actual = self.collector.collect_results('dummy_job_id')
     self.assertEqual(rows_expected, rows_actual)
 
   def test_single_page_no_rows(self):
     self.mock_jobs_service.getQueryResults().execute.return_value = {
         'totalRows': 0}
     rows_expected = []
-    rows_actual = self.collector.collect_results(self.dummy_job_id)
+    rows_actual = self.collector.collect_results('dummy_job_id')
     self.assertEqual(rows_expected, rows_actual)
 
   def test_multiple_pages(self):
@@ -114,7 +112,7 @@ class BigQueryJobResultCollectorTest(unittest.TestCase):
     rows_expected.extend(mock_result_rows1)
     rows_expected.extend(mock_result_rows2)
 
-    rows_actual = self.collector.collect_results(self.dummy_job_id)
+    rows_actual = self.collector.collect_results('dummy_job_id')
     self.assertEqual(rows_expected, rows_actual)
 
   def test_collector_translates_http_404_to_table_does_not_exist(self):
@@ -122,14 +120,14 @@ class BigQueryJobResultCollectorTest(unittest.TestCase):
         MockHttpError(404))
 
     with self.assertRaises(external.TableDoesNotExist):
-      self.collector.collect_results(self.dummy_job_id)
+      self.collector.collect_results('dummy_job_id')
 
   def test_collector_translates_http_400_to_job_failure(self):
     self.mock_jobs_service.getQueryResults().execute.side_effect = (
         MockHttpError(400))
 
     with self.assertRaises(external.BigQueryJobFailure):
-      self.collector.collect_results(self.dummy_job_id)
+      self.collector.collect_results('dummy_job_id')
 
   def test_collector_ignores_two_http_500_errors(self):
     """Keep retrying if the first two HTTP requests fail."""
@@ -140,7 +138,7 @@ class BigQueryJobResultCollectorTest(unittest.TestCase):
     self.mock_jobs_service.getQueryResults().execute.side_effect = (
         MockHttpError(500), MockHttpError(500), mock_response)
     rows_expected = mock_result_rows
-    rows_actual = self.collector.collect_results(self.dummy_job_id)
+    rows_actual = self.collector.collect_results('dummy_job_id')
     self.assertEqual(rows_expected, rows_actual)
 
   def test_collector_fails_after_five_http_500_errors(self):
@@ -149,7 +147,7 @@ class BigQueryJobResultCollectorTest(unittest.TestCase):
         MockHttpError(500))
 
     with self.assertRaises(external.BigQueryCommunicationError):
-      self.collector.collect_results(self.dummy_job_id)
+      self.collector.collect_results('dummy_job_id')
     self.assertEqual(
         5, self.mock_jobs_service.getQueryResults().execute.call_count)
 

--- a/telescope/external_test.py
+++ b/telescope/external_test.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+#
+# Copyright 2014 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import unittest
+
+import external
+
+import apiclient
+import mock
+
+
+class MockHttpError(apiclient.errors.HttpError):
+
+  def __init__(self, error_code):
+    self.resp = mock.Mock()
+    self.resp.status = error_code
+    self.uri = ''
+    self.content = ''
+
+  def __repr__(self):
+    return 'Mock HTTP Error code %d' % self.resp.status
+
+
+def _construct_mock_bigquery_response(mock_rows):
+  """Convert a list of result rows to BigQuery's response format.
+
+  Given a list of mock rows, put them in a JSON response that matches BigQuery's
+  response format (at least enough to work with BigQueryJobResultCollector).
+
+  Args:
+    mock_rows: (list) A list of dicts in which each element represents a result
+      row, e.g.:
+      [{'foo': 'bar1', 'faz': 'baz1'},
+       {'foo': 'bar2', 'faz': 'baz2'},
+       ...]
+
+  Returns:
+    (dict) A dictionary representing mock_rows in BigQuery response format.
+  """
+  mock_response = {
+      'schema': {
+          'fields': [{'name': f} for f in mock_rows[0].keys()]
+          }
+      }
+  mock_response['rows'] = []
+  for mock_row in mock_rows:
+    value_row = [{'v': v} for v in mock_row.values()]
+    mock_response['rows'].append({'f': value_row})
+  mock_response['totalRows'] = len(mock_response['rows'])
+  return mock_response
+
+
+class BigQueryJobResultCollectorTest(unittest.TestCase):
+
+  def setUp(self):
+    # Mock out calls to time.sleep to keep tests running quickly
+    sleep_patch = mock.patch.object(time, 'sleep', autospec=True)
+    self.addCleanup(sleep_patch.stop)
+    sleep_patch.start()
+
+    self.dummy_job_id = 42
+    self.dummy_project_id = 57
+    self.mock_jobs_service = mock.Mock()
+    self.collector = external.BigQueryJobResultCollector(self.mock_jobs_service,
+                                                         self.dummy_project_id)
+
+  def test_single_page_multiple_rows(self):
+    mock_result_rows = [
+        {'fieldA': 'valueA1', 'fieldB': 'valueB1'},
+        {'fieldA': 'valueA2', 'fieldB': 'valueB2'}]
+    mock_response = _construct_mock_bigquery_response(mock_result_rows)
+    self.mock_jobs_service.getQueryResults().execute.return_value = (
+        mock_response)
+    rows_expected = mock_result_rows
+    rows_actual = self.collector.collect_results(self.dummy_job_id)
+    self.assertEqual(rows_expected, rows_actual)
+
+  def test_single_page_no_rows(self):
+    self.mock_jobs_service.getQueryResults().execute.return_value = {
+        'totalRows': 0}
+    rows_expected = []
+    rows_actual = self.collector.collect_results(self.dummy_job_id)
+    self.assertEqual(rows_expected, rows_actual)
+
+  def test_multiple_pages(self):
+    # Create the first response with a page token indicating more results
+    mock_result_rows1 = [{'fieldA': 'valueA1', 'fieldB': 'valueB1'},
+                         {'fieldA': 'valueA2', 'fieldB': 'valueB2'}]
+    mock_response1 = _construct_mock_bigquery_response(mock_result_rows1)
+    mock_response1['pageToken'] = 'dummy_page_token'
+
+    # Create the second response with no additional results indicated
+    mock_result_rows2 = [{'fieldA': 'valueA3', 'fieldB': 'valueB1'},]
+    mock_response2 = _construct_mock_bigquery_response(mock_result_rows2)
+    self.mock_jobs_service.getQueryResults().execute.side_effect = (
+        mock_response1, mock_response2)
+
+    rows_expected = []
+    rows_expected.extend(mock_result_rows1)
+    rows_expected.extend(mock_result_rows2)
+
+    rows_actual = self.collector.collect_results(self.dummy_job_id)
+    self.assertEqual(rows_expected, rows_actual)
+
+  def test_collector_translates_http_404_to_table_does_not_exist(self):
+    self.mock_jobs_service.getQueryResults().execute.side_effect = (
+        MockHttpError(404))
+
+    with self.assertRaises(external.TableDoesNotExist):
+      self.collector.collect_results(self.dummy_job_id)
+
+  def test_collector_translates_http_400_to_job_failure(self):
+    self.mock_jobs_service.getQueryResults().execute.side_effect = (
+        MockHttpError(400))
+
+    with self.assertRaises(external.BigQueryJobFailure):
+      self.collector.collect_results(self.dummy_job_id)
+
+  def test_collector_ignores_two_http_500_errors(self):
+    """Keep retrying if the first two HTTP requests fail."""
+    mock_result_rows = [
+        {'fieldA': 'valueA1', 'fieldB': 'valueB1'},
+        {'fieldA': 'valueA2', 'fieldB': 'valueB2'}]
+    mock_response = _construct_mock_bigquery_response(mock_result_rows)
+    self.mock_jobs_service.getQueryResults().execute.side_effect = (
+        MockHttpError(500), MockHttpError(500), mock_response)
+    rows_expected = mock_result_rows
+    rows_actual = self.collector.collect_results(self.dummy_job_id)
+    self.assertEqual(rows_expected, rows_actual)
+
+  def test_collector_fails_after_five_http_500_errors(self):
+    """After 5 HTTP errors, bail out."""
+    self.mock_jobs_service.getQueryResults().execute.side_effect = (
+        MockHttpError(500))
+
+    with self.assertRaises(external.BigQueryCommunicationError):
+      self.collector.collect_results(self.dummy_job_id)
+    self.assertEqual(
+        5, self.mock_jobs_service.getQueryResults().execute.call_count)
+
+
+if __name__ == '__main__':
+  unittest.main()
+


### PR DESCRIPTION
This fixes a bug in Telescope where it could get caught in an infinite
loop of repeatedly querying for a job and getting an unexpected result.
With this change, Telescope will make at most 5 queries if the responses
are not success or an expected failure.

This also refactors the job retrieval code into a new class,
BigQueryJobResultCollector and adds unit test coverage for that class.